### PR TITLE
[cli] remove sqlite refs and add cli tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 - Both Search and GraphQL API endpoints
 - Account session management with cookie support
 - Email verification via IMAP for account login
-- Database persistence using PostgreSQL and SQLite
+- Database persistence using PostgreSQL
 - CLI tools for command-line usage
 
 ### Key Directories and Files
@@ -30,7 +30,7 @@
 
 ### Prerequisites
 - Python 3.10+ (supports 3.10, 3.11, 3.12, 3.13)
-- PostgreSQL (optional, SQLite used by default)
+- PostgreSQL database
 
 ### Installation
 ```bash

--- a/tests/test_cli_accounts.py
+++ b/tests/test_cli_accounts.py
@@ -1,0 +1,62 @@
+import argparse
+
+import pytest
+
+from twscrape.cli import main
+from twscrape.db_pg import fetchall
+
+
+@pytest.mark.asyncio
+async def test_cli_add_and_list_accounts(pool_mock, tmp_path, monkeypatch):
+    # prepare accounts file
+    file = tmp_path / "accounts.txt"
+    file.write_text("user1:pass1:email1:ep1\nuser2:pass2:email2:ep2\n")
+    args = argparse.Namespace(
+        command="add_accounts",
+        file_path=str(file),
+        line_format="username:password:email:email_password",
+        debug=False,
+        raw=False,
+    )
+    await main(args)
+
+    captured = []
+    monkeypatch.setattr(
+        "twscrape.cli.print_table", lambda rows, hr_after=False: captured.append(rows)
+    )
+    args = argparse.Namespace(command="accounts", debug=False, raw=False)
+    await main(args)
+
+    assert len(captured) == 1
+    usernames = {row["username"] for row in captured[0]}
+    assert usernames == {"user1", "user2"}
+
+
+@pytest.mark.asyncio
+async def test_cli_delete_accounts(pool_mock):
+    await pool_mock.add_account("u1", "p1", "e1", "ep1")
+    await pool_mock.add_account("u2", "p2", "e2", "ep2")
+
+    args = argparse.Namespace(command="del_accounts", usernames=["u1"], debug=False, raw=False)
+    await main(args)
+
+    rows = await fetchall("SELECT username FROM accounts ORDER BY username")
+    assert [r[0] for r in rows] == ["u2"]
+
+
+@pytest.mark.asyncio
+async def test_cli_stats(pool_mock, monkeypatch):
+    await pool_mock.add_account("u1", "p1", "e1", "ep1")
+    await pool_mock.set_active("u1", True)
+    from twscrape.utils import utc
+
+    await pool_mock.lock_until("u1", "SearchTimeline", utc.ts() + 60)
+
+    captured = []
+    monkeypatch.setattr(
+        "twscrape.cli.print_table", lambda rows, hr_after=False: captured.append(rows)
+    )
+    args = argparse.Namespace(command="stats", debug=False, raw=False)
+    await main(args)
+
+    assert captured and captured[0][0]["queue"] == "locked_SearchTimeline"

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1,4 +1,3 @@
-
 from twscrape.accounts_pool import AccountsPool
 from twscrape.utils import utc
 

--- a/twscrape/account.py
+++ b/twscrape/account.py
@@ -55,11 +55,10 @@ class Account(JSONTrait):
 
         doc["active"] = bool(doc["active"])
 
-        # Handle last_used - PostgreSQL returns datetime objects, SQLite returned strings
+        # Ensure last_used is converted to a datetime object
         if doc["last_used"]:
             if isinstance(doc["last_used"], str):
                 doc["last_used"] = utc.from_iso(doc["last_used"])
-            # If it's already a datetime object (PostgreSQL), keep as is
         else:
             doc["last_used"] = None
 

--- a/twscrape/api.py
+++ b/twscrape/api.py
@@ -88,7 +88,6 @@ class API:
             # Legacy: pool was a database path, now we ignore it and use database_url
             import os
 
-
             if database_url:
                 os.environ["TWSCRAPE_DATABASE_URL"] = database_url
             self.pool = AccountsPool(raise_when_no_account=raise_when_no_account)


### PR DESCRIPTION
## Summary
- drop leftover SQLite mention from docs and code
- test account commands via CLI

## Testing
- `make lint` *(fails: Import "httpx" could not be resolved)*
- `make test` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_683f5ecddfa0832c989b568da110c01f